### PR TITLE
Provides the file path of a symbol

### DIFF
--- a/lib/ngtsc/component.symbol.ts
+++ b/lib/ngtsc/component.symbol.ts
@@ -37,7 +37,7 @@ export class ComponentSymbol extends Symbol<'Component'> {
     } else {
       return scope.compilation.directives.map(d => d.selector)
         .filter(exists)
-        .map(selector => selector.split(','))
+        .map(selector => selector.split(',').map(s => s.trim()))
         .flat();
     }
   }

--- a/lib/ngtsc/symbol.ts
+++ b/lib/ngtsc/symbol.ts
@@ -42,6 +42,7 @@ export abstract class Symbol<A extends AnnotationNames> {
   protected readonly abstract annotation: A;
   protected readonly abstract deps: R3DependencyMetadata[] | 'invalid' | null;
   private _trait: GetTrait<A> | undefined;
+  private _path: string;
 
   constructor(
     protected workspace: WorkspaceSymbols,
@@ -50,6 +51,13 @@ export abstract class Symbol<A extends AnnotationNames> {
 
   get name() {
     return this.node.name.getText();
+  }
+
+  get path() {
+    if (!this._path) {
+      this._path = this.node.getSourceFile().fileName;
+    }
+    return this._path;
   }
 
   get diagnostics() {


### PR DESCRIPTION
The file path was part of the previous API of `ngast` though `getNonResolvedMetadata().type.reference`. This information is missing now so I used the Typescript API instead.
I've run some tests, and it seems that the `getSourceFile` can be an expensive operation, so I suggest to memorize the result.