### PR TITLE
Improve encapsulation and add support for external dependencies

### DIFF
--- a/lib/ngtsc/component.symbol.ts
+++ b/lib/ngtsc/component.symbol.ts
@@ -3,9 +3,10 @@ import { assertDeps, exists } from './utils';
 import { CssAst } from '../css-parser/css-ast';
 import { parseCss } from '../css-parser/parse-css';
 import { WrappedNodeExpr } from '@angular/compiler';
+import { ComponentMetadata } from './metadata';
 
 export class ComponentSymbol extends Symbol<'Component'> {
-  protected readonly annotation = 'Component';
+  readonly annotation = 'Component';
 
   private assertScope() {
     const scope = this.getScope();
@@ -16,16 +17,23 @@ export class ComponentSymbol extends Symbol<'Component'> {
     }
   }
 
-  get deps() {
-    return this.metadata.deps;
+  protected get deps() {
+    return this.analysis.meta.deps;
   }
 
-  get metadata() {
-    return this.analysis.meta;
+  get metadata(): ComponentMetadata {
+    const meta = this.analysis.meta;
+    return {
+      exportAs: meta.exportAs,
+      changeDetection: meta.changeDetection,
+      selector: meta.selector,
+      inputs: meta.inputs,
+      outputs: meta.outputs
+    }
   }
 
   /** Get the module scope of the component */
-  getScope() {
+  private getScope() {
     this.ensureAnalysis();
     return this.workspace.scopeRegistry.getScopeForComponent(this.node);
   }
@@ -70,11 +78,11 @@ export class ComponentSymbol extends Symbol<'Component'> {
 
   /** The Style AST provided by ngast */
   getStylesAst(): CssAst[] | null {
-    return this.metadata.styles.map(s => parseCss(s));
+    return this.analysis.meta.styles.map(s => parseCss(s));
   }
 
   /** The Template AST provided by Ivy */
   getTemplateAst() {
-    return this.metadata.template.nodes;
+    return this.analysis.meta.template.nodes;
   }
 }

--- a/lib/ngtsc/component.symbol.ts
+++ b/lib/ngtsc/component.symbol.ts
@@ -17,7 +17,8 @@ export class ComponentSymbol extends Symbol<'Component'> {
     }
   }
 
-  protected get deps() {
+  /** @internal */
+  get deps() {
     return this.analysis.meta.deps;
   }
 

--- a/lib/ngtsc/component.symbol.ts
+++ b/lib/ngtsc/component.symbol.ts
@@ -73,7 +73,7 @@ export class ComponentSymbol extends Symbol<'Component'> {
   /** Return dependencies injected in the constructor of the component */
   getDependencies() {
     assertDeps(this.deps, this.name);
-    return this.deps.map(dep => this.workspace.findSymbol(dep.token)).filter(exists);
+    return this.deps.map(dep => this.workspace.findSymbol(dep.token, this.path)).filter(exists);
   }
 
   /** The Style AST provided by ngast */

--- a/lib/ngtsc/directive.symbol.ts
+++ b/lib/ngtsc/directive.symbol.ts
@@ -1,16 +1,23 @@
 import { Symbol } from './symbol';
 import { assertDeps, exists } from './utils';
 import { WrappedNodeExpr } from '@angular/compiler';
+import { DirectiveMetadata } from './metadata';
 
 export class DirectiveSymbol extends Symbol<'Directive'> {
-  protected readonly annotation = 'Directive';
+  readonly annotation = 'Directive';
 
-  get deps() {
-    return this.metadata.deps;
+  protected get deps() {
+    return this.analysis.meta.deps;
   }
 
-  get metadata() {
-    return this.analysis.meta;
+  get metadata(): DirectiveMetadata {
+    const meta = this.analysis.meta;
+    return {
+      exportAs: meta.exportAs,
+      selector: meta.selector,
+      inputs: meta.inputs,
+      outputs: meta.outputs
+    };
   }
 
   /**

--- a/lib/ngtsc/directive.symbol.ts
+++ b/lib/ngtsc/directive.symbol.ts
@@ -6,7 +6,8 @@ import { DirectiveMetadata } from './metadata';
 export class DirectiveSymbol extends Symbol<'Directive'> {
   readonly annotation = 'Directive';
 
-  protected get deps() {
+  /** @internal */
+  get deps() {
     return this.analysis.meta.deps;
   }
 

--- a/lib/ngtsc/injectable.symbol.ts
+++ b/lib/ngtsc/injectable.symbol.ts
@@ -5,7 +5,8 @@ import { assertDeps, exists } from './utils';
 export class InjectableSymbol extends Symbol<'Injectable'> {
   readonly annotation = 'Injectable';
 
-  protected get deps() {
+  /** @internal */
+  get deps() {
     return this.metadata.userDeps
       ? this.metadata?.userDeps
       : this.analysis.ctorDeps;

--- a/lib/ngtsc/injectable.symbol.ts
+++ b/lib/ngtsc/injectable.symbol.ts
@@ -3,15 +3,15 @@ import { assertDeps, exists } from './utils';
 
 
 export class InjectableSymbol extends Symbol<'Injectable'> {
-  protected readonly annotation = 'Injectable';
+  readonly annotation = 'Injectable';
 
-  get deps() {
+  protected get deps() {
     return this.metadata.userDeps
       ? this.metadata?.userDeps
       : this.analysis.ctorDeps;
   }
 
-  get metadata() {
+  protected get metadata() {
     return this.analysis.meta;
   }
 

--- a/lib/ngtsc/metadata.ts
+++ b/lib/ngtsc/metadata.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy } from '@angular/core';
+
+export interface DirectiveMetadata {
+  exportAs: string[] | null;
+  selector: string | null;
+  inputs: {[field: string]: string | [string, string]};
+  outputs: {[field: string]: string};
+}
+
+export interface ComponentMetadata extends DirectiveMetadata {
+  changeDetection: ChangeDetectionStrategy | undefined;
+}

--- a/lib/ngtsc/module.symbol.ts
+++ b/lib/ngtsc/module.symbol.ts
@@ -4,7 +4,7 @@ import type { ComponentSymbol } from './component.symbol';
 import { assertDeps, exists } from './utils';
 
 export class NgModuleSymbol extends Symbol<'NgModule'> {
-  protected readonly annotation = 'NgModule';
+  readonly annotation = 'NgModule';
 
   get deps() {
     return this.analysis.inj.deps;
@@ -32,7 +32,7 @@ export class NgModuleSymbol extends Symbol<'NgModule'> {
 
   /**
    * Get all declaration class of the module as `ComponentSymbol | PipeSymbol | DirectiveSymbol`
-   * You can filter them using `declaration.isSymbol(name)` method: 
+   * You can filter them using `declaration.isSymbol(name)` method:
    * @example
    * ```typescript
    * const declarations = module.getDeclarations()
@@ -58,7 +58,7 @@ export class NgModuleSymbol extends Symbol<'NgModule'> {
 
   /**
    * Get all declaration class of the module as `ComponentSymbol | PipeSymbol | DirectiveSymbol`
-   * You can filter them using `exported.isSymbol(name)` method: 
+   * You can filter them using `exported.isSymbol(name)` method:
    * @example
    * ```typescript
    * const exported = module.getExports()

--- a/lib/ngtsc/module.symbol.ts
+++ b/lib/ngtsc/module.symbol.ts
@@ -6,6 +6,7 @@ import { assertDeps, exists } from './utils';
 export class NgModuleSymbol extends Symbol<'NgModule'> {
   readonly annotation = 'NgModule';
 
+  /** @internal */
   get deps() {
     return this.analysis.inj.deps;
   }

--- a/lib/ngtsc/pipe.symbol.ts
+++ b/lib/ngtsc/pipe.symbol.ts
@@ -4,7 +4,8 @@ import { assertDeps, exists } from './utils';
 export class PipeSymbol extends Symbol<'Pipe'> {
   readonly annotation = 'Pipe';
 
-  protected get deps() {
+  /** @internal */
+  get deps() {
     return this.metadata.deps;
   }
 

--- a/lib/ngtsc/pipe.symbol.ts
+++ b/lib/ngtsc/pipe.symbol.ts
@@ -2,9 +2,9 @@ import { Symbol } from './symbol';
 import { assertDeps, exists } from './utils';
 
 export class PipeSymbol extends Symbol<'Pipe'> {
-  protected readonly annotation = 'Pipe';
+  readonly annotation = 'Pipe';
 
-  get deps() {
+  protected get deps() {
     return this.metadata.deps;
   }
 

--- a/lib/ngtsc/symbol.ts
+++ b/lib/ngtsc/symbol.ts
@@ -3,13 +3,11 @@ import { ClassDeclaration, DeclarationNode, Decorator } from '@angular/compiler-
 import { TraitState, Trait, AnalyzedTrait, ResolvedTrait } from '@angular/compiler-cli/src/ngtsc/transform';
 import { R3DependencyMetadata } from '@angular/compiler';
 import { AnnotationNames } from './utils';
-import { FactoryOutput } from './find-symbol';
 import { NgModuleAnalysis } from '@angular/compiler-cli/src/ngtsc/annotations/src/ng_module';
 import { PipeHandlerData } from '@angular/compiler-cli/src/ngtsc/annotations/src/pipe';
 import { InjectableHandlerData } from '@angular/compiler-cli/src/ngtsc/annotations/src/injectable';
 import { DirectiveHandlerData } from '@angular/compiler-cli/src/ngtsc/annotations/src/directive';
 import { ComponentAnalysisData } from '@angular/compiler-cli/src/ngtsc/annotations/src/component';
-import { isFromDtsFile } from '@angular/compiler-cli/src/ngtsc/util/src/typescript';
 
 const handlerName = {
   'NgModule': 'NgModuleDecoratorHandler',
@@ -39,7 +37,7 @@ export const isAnalysed = <A, B, C>(trait?: Trait<A, B, C>): trait is AnalyzedTr
 }
 
 export abstract class Symbol<A extends AnnotationNames> {
-  protected readonly abstract annotation: A;
+  readonly abstract annotation: A;
   protected readonly abstract deps: R3DependencyMetadata[] | 'invalid' | null;
   private _trait: GetTrait<A> | undefined;
   private _path: string;
@@ -73,7 +71,7 @@ export abstract class Symbol<A extends AnnotationNames> {
   }
 
   /** The record of the ClassDeclaration in the trait compiler */
-  get record() {
+  private get record() {
     return this.workspace.traitCompiler.recordFor(this.node);
   }
 
@@ -111,15 +109,5 @@ export abstract class Symbol<A extends AnnotationNames> {
     if (!this.record) {
       this.analyse();
     }
-  }
-
-  /** Type check the current symbol against an Annotation */
-  public isSymbol(name: AnnotationNames): this is FactoryOutput<A> {
-    return this.annotation === name;
-  }
-
-  /** Check if symbol is from node_modules */
-  public isDts(): boolean {
-    return isFromDtsFile(this.node);
   }
 }

--- a/lib/ngtsc/workspace.symbols.ts
+++ b/lib/ngtsc/workspace.symbols.ts
@@ -134,7 +134,7 @@ export class WorkspaceSymbols {
   }
 
 
-  /** Evaluate typecript Expression & update the dependancy graph accordingly */
+  /** Evaluate typescript Expression & update the dependency graph accordingly */
   public get evaluator() {
     return this.lazy('evaluator', () => new PartialEvaluator(
       this.reflector,

--- a/lib/ngtsc/workspace.symbols.ts
+++ b/lib/ngtsc/workspace.symbols.ts
@@ -199,9 +199,9 @@ export class WorkspaceSymbols {
       const module = token.value.moduleName ?? '';
       const moduleName = module.endsWith('.ts') ? module : `${module}.ts`;
       const path = join(dir, moduleName);
-      return this.getAllInjectable().filter(injectable => {
+      return this.getAllInjectable().find(injectable => {
         return injectable.path === path && injectable.name === token.value.name
-      }).pop();
+      });
     }
   }
 

--- a/test/fixture/ngtsc-external-deps/index.ts
+++ b/test/fixture/ngtsc-external-deps/index.ts
@@ -1,0 +1,58 @@
+import { NgModule, Component, Inject, Injectable, InjectionToken, Directive, Pipe, PipeTransform } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CommonModule } from '@angular/common';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { BasicProvider, TOKEN } from './services';
+
+
+@Component({
+  selector: 'main-component',
+  template: '<div>Hello world</div>',
+  providers: [{ provide: TOKEN, useValue: true }],
+})
+export class MainComponent {
+  visible: boolean;
+  constructor(
+    public p: BasicProvider,
+    @Inject('primitive') public primitive,
+    @Inject(TOKEN) public isTrue,
+  ) {}
+}
+
+@Directive({
+  selector: '[main]',
+  providers: [{ provide: TOKEN, useValue: false }]
+})
+export class MainDirective {
+  constructor(public p: BasicProvider) {}
+}
+
+@Injectable()
+export class CompositeProvider {
+  constructor(
+    public p: BasicProvider,
+    @Inject('primitive') public primitive: string,
+  ) {}
+}
+
+@Pipe({ name: 'main' })
+export class MainPipe implements PipeTransform {
+  constructor(public p: BasicProvider) {}
+  transform(value: any) {
+    return value;
+  }
+}
+
+@NgModule({
+  imports: [CommonModule, BrowserModule, MatExpansionModule, BrowserAnimationsModule],
+  exports: [MainComponent],
+  declarations: [MainComponent, MainDirective, MainPipe],
+  bootstrap: [MainComponent],
+  providers: [
+    CompositeProvider,
+    BasicProvider,
+    { provide: 'primitive', useValue: '42' },
+  ]
+})
+export class AppModule {}

--- a/test/fixture/ngtsc-external-deps/services.ts
+++ b/test/fixture/ngtsc-external-deps/services.ts
@@ -1,0 +1,6 @@
+import { Injectable, InjectionToken } from "@angular/core";
+
+@Injectable()
+export class BasicProvider {}
+
+export const TOKEN = new InjectionToken('token');

--- a/test/fixture/ngtsc-external-deps/tsconfig.json
+++ b/test/fixture/ngtsc-external-deps/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node"
+  },
+  "files": [
+    "index.ts"
+  ]
+}

--- a/test/ngtsc/component.spec.ts
+++ b/test/ngtsc/component.spec.ts
@@ -16,7 +16,7 @@ describe('ComponentSymbol', () => {
     it('Should get the component', () => {
       const [component] = workspace.getAllComponents();
       expect(component.name).toBe('MainComponent');
-      expect(component.isSymbol('Component')).toBeTrue();
+      expect(component.annotation).toBe('Component');
       expect(component.metadata.selector).toBe('main-component');
     });
   });

--- a/test/ngtsc/component.spec.ts
+++ b/test/ngtsc/component.spec.ts
@@ -69,4 +69,18 @@ describe('ComponentSymbol', () => {
       expect(selectors.includes('date')).toBeTrue();
     })
   });
+
+  describe('external deps', () => {
+    let workspace: WorkspaceSymbols;
+    const folder = getFolder('ngtsc-external-deps');
+
+    beforeEach(() => workspace = new WorkspaceSymbols(`${folder}/tsconfig.json`));
+
+    it('Should get external providers', () => {
+      const [component] = workspace.getAllComponents();
+      const [basic, primitive] = component.getDependencies();
+      expect(basic.name).toBe('BasicProvider');
+      expect(primitive.name).toBe('primitive');
+    })
+  })
 });

--- a/test/ngtsc/directive.spec.ts
+++ b/test/ngtsc/directive.spec.ts
@@ -16,7 +16,7 @@ describe('DirectiveSymbol', () => {
     it('Should get the directive', () => {
       const [directive] = workspace.getAllDirectives();
       expect(directive.name).toBe('MainDirective');
-      expect(directive.isSymbol('Directive')).toBeTrue();
+      expect(directive.annotation).toBe('Directive');
       expect(directive.metadata.selector).toBe('[main]');
     });
   });

--- a/test/ngtsc/injectable.spec.ts
+++ b/test/ngtsc/injectable.spec.ts
@@ -16,7 +16,7 @@ describe('InjectionSymbol', () => {
       // None decorated @Injectable are not visible since v9
       const [basicView] = workspace.getAllInjectable();
       expect(basicView.name).toBe('BasicViewProvider');
-      expect(basicView.isSymbol('Injectable')).toBeTrue();
+      expect(basicView.annotation).toBe('Injectable');
     });
   });
 

--- a/test/ngtsc/injectable.spec.ts
+++ b/test/ngtsc/injectable.spec.ts
@@ -33,5 +33,10 @@ describe('InjectionSymbol', () => {
       expect(primitive.name).toBe('primitive');
     });
 
+    it('Should get module providers', () => {
+      const [m] = workspace.getAllModules();
+      const provider = m.getProviders().filter(p => p.name === 'BasicProvider').pop();
+      expect(provider).not.toBeUndefined();
+    });
   });
 });

--- a/test/ngtsc/module.spec.ts
+++ b/test/ngtsc/module.spec.ts
@@ -21,11 +21,11 @@ describe('WorkspaceSymbols', () => {
     it('Get declarations with right Symbol', () => {
       const [module] = workspace.getAllModules();
       const [component, directive, pipe] = module.getDeclarations();
-      expect(component.isSymbol('Component')).toBeTruthy();
+      expect(component.annotation).toBe('Component');
       expect(component.name).toBe('MainComponent');
-      expect(directive.isSymbol('Directive')).toBeTruthy();
+      expect(directive.annotation).toBeTruthy('Directive');
       expect(directive.name).toBe('MainDirective');
-      expect(pipe.isSymbol('Pipe')).toBeTruthy();
+      expect(pipe.annotation).toBe('Pipe');
       expect(pipe.name).toBe('MainPipe');
     });
 
@@ -39,7 +39,7 @@ describe('WorkspaceSymbols', () => {
     it('Get exports with right Symbol', () => {
       const [module] = workspace.getAllModules();
       const [exports] = module.getExports();
-      expect(exports.isSymbol('Component')).toBeTruthy();
+      expect(exports.annotation).toBe('Component');
       expect(exports.name).toBe('MainComponent');
     });
 
@@ -49,19 +49,6 @@ describe('WorkspaceSymbols', () => {
       expect(bootstrap.name).toBe('MainComponent');
     });
   });
-
-  describe('is dts', () => {
-    let workspace: WorkspaceSymbols;
-    const folder = getFolder('ngtsc-dts');
-    beforeEach(() => workspace = new WorkspaceSymbols(`${folder}/tsconfig.json`));
-
-    it('Check when module is dts or not', () => {
-      const [_, module] = workspace.getAllModules();
-      const [browser, local] = module.getImports();
-      expect(browser.isDts()).toBeTrue();
-      expect(local.isDts()).toBeFalse();
-    });
-  })
 
   describe('basic primitive token', () => {
     let workspace: WorkspaceSymbols;

--- a/test/ngtsc/pipe.spec.ts
+++ b/test/ngtsc/pipe.spec.ts
@@ -15,7 +15,7 @@ describe('PipeSymbol', () => {
     it('Should get the pipe', () => {
       const [pipe] = workspace.getAllPipes();
       expect(pipe.name).toBe('MainPipe');
-      expect(pipe.isSymbol('Pipe')).toBeTrue();
+      expect(pipe.annotation).toBe('Pipe');
       expect(pipe.metadata.pipeName).toBe('main');
     });
   });


### PR DESCRIPTION
This PR introduces few major changes:
- Removes *some* of the public facing API dependencies on `@angular/compiler`. Ideally, we'd want to remove them all so that we can keep the API consistent in the future in case compiler's interface changes.
- Makes the `annotation` property public. I think it's cleaner than having `public isSymbol` because it works better with type inference.
- Removed the public method `isDts` to shrink the API surface.
- Introduced support for dependencies defined in external modules. It might be suboptimal. If you have better ideas let me know and we can improve the implementation.